### PR TITLE
Merge issue-3125 (Compiled minor changes) to main

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -18,27 +18,30 @@ const ProjectsAdminPage = async () => {
 
   return (
     <main>
-      <Container id="list" className="py-3">
-        <Row>
-          <Col>
+      <Container fluid id="list" className="py-3">
+        <Row className="justify-content-center">
+          <Col lg={11}>
             <h1>List Projects Admin</h1>
-            <Table striped bordered hover>
-              <thead>
-                <tr>
-                  <th>Id #</th>
-                  <th>Title</th>
-                  <th>Description</th>
-                  <th>Due Date</th>
-                  <th>Image</th>
-                  <th>Edit</th>
-                </tr>
-              </thead>
-              <tbody>
-                {projects.map((project) => (
-                  <ProjectsList key={project.id} {...project} />
-                ))}
-              </tbody>
-            </Table>
+            {/* Wrap table in scrollable div */}
+            <div style={{ overflowX: 'auto' }}>
+              <Table striped bordered hover>
+                <thead>
+                  <tr>
+                    <th style={{ width: '50px' }}>Id #</th>
+                    <th style={{ width: '150px' }}>Title</th>
+                    <th style={{ maxWidth: '300px', wordBreak: 'break-word' }}>Description</th>
+                    <th style={{ width: '120px' }}>Due Date</th>
+                    <th style={{ width: '100px' }}>Image</th>
+                    <th style={{ width: '80px' }}>Edit</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {projects.map((project) => (
+                    <ProjectsList key={project.id} {...project} />
+                  ))}
+                </tbody>
+              </Table>
+            </div>
           </Col>
         </Row>
       </Container>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -12,13 +12,14 @@ const UsersAdminPage = async () => {
       user: { email: string; id: string; randomKey: string };
     } | null,
   );
+
   const users = await prisma.user.findMany({});
 
   return (
     <main>
-      <Container id="list" className="py-3">
-        <Row>
-          <Col>
+      <Container fluid id="list" className="py-3">
+        <Row className="justify-content-center">
+          <Col lg={11}>
             <h1>List Users Admin</h1>
             <UserListClient users={users} />
           </Col>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -600,3 +600,25 @@ img.padded {
   cursor: pointer;
   padding: 10px 30px;
 }
+
+.masonry-grid {
+  column-count: 2;
+  column-gap: 1.5rem;
+}
+
+.masonry-item {
+  break-inside: avoid;
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 992px) {
+  .masonry-grid {
+    column-count: 1;
+  }
+}
+
+.user-left-col h6,
+.user-left-col h1 {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}

--- a/src/app/project-opening/application/[id]/page.tsx
+++ b/src/app/project-opening/application/[id]/page.tsx
@@ -56,7 +56,7 @@ const ApplicationPage = async ({ params }: { params: Promise<{
 
   if (applic.userId == user.id) {
     return (
-      <Container>
+      <Container style={{ marginTop: '25px' }}>
         <Link href={`/project-opening/${applic.position.project?.id ?? ''}`}>Back to Opening</Link>
         <ApplicationUser
           user={user}
@@ -71,7 +71,7 @@ const ApplicationPage = async ({ params }: { params: Promise<{
   }
   else if ((applic.position.admins?.some((a) => a.id === user.id) ?? false) || (user.role === 'ADMIN')) {
     return (
-      <Container>
+      <Container style={{ marginTop: '25px' }}>
         <Link href={`/project-opening/${applic.position.project?.id ?? ''}`}>Back to Opening</Link>
         <ApplicationAdmin
           user={user}
@@ -85,7 +85,7 @@ const ApplicationPage = async ({ params }: { params: Promise<{
     );
   }
   return (
-    <Container>
+    <Container style={{ marginTop: '25px' }}>
       <Link href={`/project-page/${applic.position.id ?? ''}`}>Back to Position</Link>
       <h1>
         Permissions denied.

--- a/src/components/AddOpeningForm.tsx
+++ b/src/components/AddOpeningForm.tsx
@@ -198,7 +198,7 @@ const AddOpeningForm: React.FC<AddOpeningFormProps> = ({ projectId }) => {
                   <textarea
                     {...register('descrip')}
                     className={`form-control ${errors.descrip ? 'is-invalid' : ''}`}
-                    style={{ height: '120px' }}
+                    style={{ height: '400px' }}
                   />
                   <div className="invalid-feedback">{errors.descrip?.message}</div>
                 </Form.Group>

--- a/src/components/AddProjectForm.tsx
+++ b/src/components/AddProjectForm.tsx
@@ -230,7 +230,7 @@ const AddProjectForm: React.FC = () => {
                   <textarea
                     {...register('descrip')}
                     className={`form-control ${errors.descrip ? 'is-invalid' : ''}`}
-                    style={{ height: '300px' }}
+                    style={{ height: '400px' }}
                   />
                   <div className="invalid-feedback">{errors.descrip?.message}</div>
                 </Form.Group>

--- a/src/components/ApplicationAdmin.tsx
+++ b/src/components/ApplicationAdmin.tsx
@@ -23,19 +23,22 @@ const ApplicationAdmin: React.FC<ApplicationAdminProps> = ({ applic, user }) => 
   const router = useRouter();
 
   return (
-    <Container fluid className="py-3">
+    <Container fluid className="py-3" style={{ marginBottom: '35px' }}>
       <Row>
         <h2>Applicant:</h2>
         <p>{user.firstName} {user.lastName}</p>
       </Row>
       <Row>
         <h2>Application Text:</h2>
-        <p>{applic.application}</p>
+        <div style={{ whiteSpace: 'pre-wrap', fontSize: '0.9rem', color: '#333' }}>
+          {applic.application}
+        </div>
       </Row>
       <Row>
         <Col>
             <Button
             type="button"
+            style={{ marginTop: '30px' }}
             onClick={async (event) => {
               event.preventDefault();
               event.stopPropagation();
@@ -69,6 +72,8 @@ const ApplicationAdmin: React.FC<ApplicationAdminProps> = ({ applic, user }) => 
         <Col>
           <Button
             type="button"
+            style={{ marginTop: '30px' }}
+            variant="danger"
             onClick={async (event) => {
               event.preventDefault();
               event.stopPropagation();

--- a/src/components/ApplicationUser.tsx
+++ b/src/components/ApplicationUser.tsx
@@ -23,22 +23,26 @@ const ApplicationUser: React.FC<ApplicationAdminProps> = ({ applic, user }) => {
   const router = useRouter();
 
   return (
-    <Container fluid className="py-3">
+    <Container fluid className="py-3" style={{ marginBottom: '35px' }} id="application">
       <Row>
         <h2>Applicant:</h2>
         <p>{user.firstName} {user.lastName}</p>
       </Row>
       <Row>
         <h2>Application Text:</h2>
-        <p>{applic.application}</p>
+        <div style={{ whiteSpace: 'pre-wrap', fontSize: '0.9rem', color: '#333' }}>
+          {applic.application}
+        </div>
       </Row>
       <Row>
         <Col>
-            <Button variant="primary" href={`/project-opening/edit-application/${applic.id}`}>Edit Application</Button>
+          <Button variant="primary" href={`/project-opening/edit-application/${applic.id}`} style={{ marginTop: '30px' }}>Edit Application</Button>
         </Col>
         <Col>
           <Button
+            style={{ marginTop: '30px' }}
             type="button"
+            variant="danger"
             onClick={async (event) => {
               event.preventDefault();
               event.stopPropagation();
@@ -66,7 +70,7 @@ const ApplicationUser: React.FC<ApplicationAdminProps> = ({ applic, user }) => {
                   router.push(`/project-opening/application/${applic.id}`)
                 }
             }}}
-            className="float-right"
+            className="float-right btn-reset"
           >
             DELETE
           </Button>

--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -18,10 +18,10 @@ const NON_CLICKABLE_SEGMENTS = [
   'not-authorized',
   'passchange',
   'project-opening',
-  'project-page',
   'signup',
   'user-profile',
   'verify',
+  'auth',
 ];
 
 // Optional overrides for specific paths
@@ -32,6 +32,7 @@ const PATH_OVERRIDES: Record<string, { label: string; href?: string; clickable?:
   '/auth/signout': { label: 'Sign Out', clickable: false },
   '/auth/forgot-password': { label: 'Forgot Password', clickable: false },
   '/auth/forgot-username': { label: 'Forgot Username', clickable: false },
+  '/project-page': { label: 'Projects List', href: '/project-list', clickable: true},
 };
 
 // Static folder names for nicer labels

--- a/src/components/EditOpeningForm.tsx
+++ b/src/components/EditOpeningForm.tsx
@@ -255,9 +255,6 @@ const EditOpeningForm: React.FC<EditOpeningFormProps> = ({ position }) => {
                     </div>
                   </Form.Group>
                 )}
-
-
-
                 <Form.Group className="form-group mt-3" >
                   <Row>
                     <Col>

--- a/src/components/EditProjectForm.tsx
+++ b/src/components/EditProjectForm.tsx
@@ -164,7 +164,7 @@ const EditProjectForm: React.FC<EditProjectFormProps> = ({ proj, members, admins
 
       reset();
       handleImgDel();
-      router.push('/project-list');
+      router.push(`/project-page/${proj.id}`);
     } catch {
       swal('Error', 'Something went wrong.', 'error');
     }
@@ -292,7 +292,7 @@ const EditProjectForm: React.FC<EditProjectFormProps> = ({ proj, members, admins
                 <Row className="pt-3" style={{ marginTop: '10px' }}>
                   <Col>
                     <Button type="submit" variant="primary" className="btn-submit">
-                      Submit
+                      Update
                     </Button>
                   </Col>
                   <Col>

--- a/src/components/EditUserForm.tsx
+++ b/src/components/EditUserForm.tsx
@@ -307,7 +307,7 @@ function EditUserForm({ user }: { user: User }) {
                 <Form.Group className="mt-3">
                   <Row>
                     <Col>
-                      <Button type="submit" variant="primary" className="btn-submit">Submit</Button>
+                      <Button type="submit" variant="primary" className="btn-submit">Update</Button>
                     </Col>
                     <Col className="text-end">
                       <Button type="button" onClick={handleReset} className="btn-reset" variant="warning">Revert</Button>

--- a/src/components/MemberName.tsx
+++ b/src/components/MemberName.tsx
@@ -19,17 +19,16 @@ const MemberName = async ({ userid }: { userid: number }) => {
     >
       <Button variant="primary" className="member-button">
         <img
-  src={member.image || "/default-profile.jpg"}
-  alt={`${member.firstName} ${member.lastName}`}
-  width={32}
-  height={32}
-  style={{
-    borderRadius: "50%",
-    objectFit: "cover",
-    marginRight: "5px",
-  }}
-/>
-
+          src={member.image || "/default-profile.jpg"}
+          alt={`${member.firstName} ${member.lastName}`}
+          width={32}
+          height={32}
+          style={{
+            borderRadius: "50%",
+            objectFit: "cover",
+            marginRight: "5px",
+          }}
+        />
         {member.firstName}
         &nbsp;
         {member.lastName}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -73,8 +73,8 @@ const ProjectCard = ({ project }: { project: ProjectWithPositions }) => {
                 id="proj-descrip"
                 style={{ whiteSpace: 'pre-line' }}
               >
-                {project.descrip.length > 650
-                  ? project.descrip.slice(0, 650) + '...'
+                {project.descrip.length > 420
+                  ? project.descrip.slice(0, 420) + '...'
                   : project.descrip}
               </CardText>
               {/* Openings */}

--- a/src/components/ProjectInfo.tsx
+++ b/src/components/ProjectInfo.tsx
@@ -53,10 +53,18 @@ const ProjectInfo = async ({ params }: { params: { id: number } }) => {
       </Row>
 
       {/* Description */}
-      <Row className="mt-3">
+      <Row className="mt-3" >
         <Col>
           <strong>Description:</strong>
-          <div id="proj-descrip" style={{ whiteSpace: 'pre-line', marginTop: '0.5rem' }}>
+          <div
+            id="proj-descrip"
+            style={{
+              whiteSpace: 'pre-line',
+              marginTop: '0.5rem',
+              wordBreak: 'break-word',
+              overflowWrap: 'anywhere',
+            }}
+          >
             {project.descrip}
           </div>
         </Col>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -41,7 +41,7 @@ const UserProfile = async ({ user }: { user: UserWithContacts }) => {
 
   return (
     <Row>
-      <Col lg={3}>
+      <Col lg={3} className="user-left-col">
         <img
           src={user.image && user.image.trim() !== "" ? user.image : "/default-profile.jpg"}
           alt={`${user.firstName} ${user.lastName}`}
@@ -80,17 +80,13 @@ const UserProfile = async ({ user }: { user: UserWithContacts }) => {
       </Col>
       <Col lg={9} className='px-3'>
         <h2 className="mb-4">Projects</h2>
-          <Row className="g-4">
-            {projects.length === 0 && (
-              <p>This user is not part of any projects.</p>
-            )}
-
+         <div className="masonry-grid">
             {projects.map((project) => (
-              <Col key={project.id} xs={12} md={6} lg={6}>
+              <div key={project.id} className="masonry-item">
                 <UserProjectCard project={project} />
-              </Col>
+              </div>
             ))}
-          </Row>
+          </div>
       </Col>
       <Col>
         {

--- a/src/lib/validationSchemas.ts
+++ b/src/lib/validationSchemas.ts
@@ -30,7 +30,9 @@ export const EditUserSchema = Yup.object({
 });
 
 export const AddProjectSchema = Yup.object({
-  title: Yup.string().required('Title is required'),
+  title: Yup.string()
+    .required('Title is required')
+    .max(60, 'Title must be at most 60 characters'),
   descrip: Yup.string().required('Description is required'),
   members: Yup.array().of(Yup.number().defined()).default([]),
   admins: Yup.array().of(Yup.number().defined()).default([]),
@@ -41,7 +43,9 @@ export const AddProjectSchema = Yup.object({
 export const EditProjectSchema = Yup.object({
   id: Yup.number().required(),
   image: Yup.string(),
-  title: Yup.string().required(),
+  title: Yup.string()
+    .required()
+    .max(60, 'Title must be at most 60 characters'),
   descrip: Yup.string().required(),
   positions: Yup.array().of(Yup.number()).required(),
   members: Yup.array()


### PR DESCRIPTION
Catch-all branch for adding minor changes.

Limit text count display for Project Cards in project list page. Particularly, descriptions being too long

Limit text count display for titles

Change word "Submit" --> "Update" in (Edit User Form, Edit Project Form)

Check PostedByCard, seems to update "Poster" as the most recently added admin in logic

Update Admin pages to fit page (Currently rolling off page without ability to scroll)

Update UI colors for Application (Edit Application, View applications)

Check all displays on mobile for issues

Update Application text field to save line breaks (like how text area for project descriptions preserve line breaks truncated)

Expand default text height of text areas as need (i.e. Add Project / Add Opening / Application )

Update faulty BreadcrumbBar links: Auth should not be accessible. Project should be Project List in project page root

Test faulty tags logic in Skills list display (adding more skills that was not added to openings)

Fix UserProjectsCard to wrap auto. Currently, it is dividing by rows, so there may be empty space between smaller cards. A proposed solution is to set definite size and limit desc. display text or wrap automatically when column space is free.

Change the redirect after editing a project to that project's page [id]

Add slight margin to User Projects section of user profile page (long emails like teamuhp admin are right next to the project cards) OR allow word breaks

Allow word breaks or word wrap in project info project description. It is currently allowed to bleed out into the right section column.